### PR TITLE
[1.20.1] Remove unsupported quiet compiler argument

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,6 @@ generateModMetadata.doFirst {
 tasks.withType(JavaCompile).configureEach {
     options.encoding = "UTF-8"
     options.compilerArgs << "-Xlint:-removal"
-    options.compilerArgs << "-Aquiet=true"// 忽略删除和过时，真删了报错再说吧
 }
 
 tasks.named('compileJava', JavaCompile) {
@@ -138,3 +137,4 @@ jacocoTestReport {
         }))
     }
 }
+


### PR DESCRIPTION
## What / 目的
This PR removes an unsupported Java compiler argument from the 1.20.1 build script.

## Implementation Details / 实现细节
- Deletes the `-Aquiet=true` compiler argument from the shared JavaCompile configuration.

## Outcome / 结果
- Build output no longer emits the warning about the unrecognized `[quiet]` option.
- The compile configuration is kept functionally the same aside from removing the unsupported argument.

## Potential Compatibility Issues / 潜在兼容性问题
- No runtime, API, recipe, or data compatibility changes are introduced.