### PR TITLE
[1.21.1] 适配语言提供器与创造流体处理器的当前 API

### DIFF
--- a/src/main/java/cn/qiuye/gtmoremachine/api/lang/ChineseLangProvider.java
+++ b/src/main/java/cn/qiuye/gtmoremachine/api/lang/ChineseLangProvider.java
@@ -17,7 +17,8 @@ import java.util.concurrent.CompletableFuture;
 @MethodsReturnNonnullByDefault
 public class ChineseLangProvider extends LanguageProvider implements RegistrateProvider {
 
-    public static final ProviderType<ChineseLangProvider> LANG = ProviderType.register("cn_lang", (registrate, vanillaPack) -> new ChineseLangProvider(registrate, vanillaPack.getGenerator().getPackOutput()));
+    public static final ProviderType<ChineseLangProvider> LANG = ProviderType.registerProvider("cn_lang",
+            context -> new ChineseLangProvider(context.parent(), context.output()));
 
     private static class TraditionalChineseLangProvider extends LanguageProvider {
 

--- a/src/main/java/cn/qiuye/gtmoremachine/api/misc/CreativeFluidHandlerItemStack.java
+++ b/src/main/java/cn/qiuye/gtmoremachine/api/misc/CreativeFluidHandlerItemStack.java
@@ -22,7 +22,7 @@ public class CreativeFluidHandlerItemStack extends FluidHandlerItemStack impleme
 
     @Override
     public @NotNull FluidStack drain(FluidStack resource, FluidAction action) {
-        if (resource.isFluidEqual(this.getFluid())) {
+        if (FluidStack.isSameFluidSameComponents(resource, this.getFluid())) {
             if (capacity == Integer.MAX_VALUE) {
                 return resource.copy();
             } else {


### PR DESCRIPTION
## What / 目的
此 PR 仅处理 1.21.1 分支上的两处专属 API 适配，避免与可回移到 1.20.1 的共享修复混在一起。

## Implementation Details / 实现细节
- 将 `ChineseLangProvider` 调整为使用 1.21.1 分支当前使用的 Registrate provider 注册方式。
- 将 `CreativeFluidHandlerItemStack` 调整为使用当前的流体与组件比较 API，替换旧的比较方式。
- 本次修改范围仅限这两个 1.21.1 专属文件，不包含共享逻辑修复。

## Outcome / 结果
- 消除 `ChineseLangProvider` 中的当前分支过时 API 用法。
- 使 `CreativeFluidHandlerItemStack` 与 1.21.1 当前流体组件比较方式保持一致。
- 将 1.21.1 专属 API 适配与共享修复拆分，方便分别审查与合并。

## Potential Compatibility Issues / 潜在兼容性问题
- 此 PR 为 1.21.1 专属适配。
- 这里使用的相关 API 在 1.20.1 分支中并不以相同形式存在，因此不应直接回移。
