### PR TITLE
修复创造流体单元物品模型定义

### DIFF
--- a/src/main/resources/assets/gtmoremachine/models/item/creative_fluid_cell.json
+++ b/src/main/resources/assets/gtmoremachine/models/item/creative_fluid_cell.json
@@ -1,6 +1,6 @@
 {
-	"loader": "forge:fluid_container",
-	"parent": "forge:item/default",
+	"loader": "neoforge:fluid_container",
+	"parent": "neoforge:item/default",
 	"textures": {
 		"base": "gtmoremachine:item/creative_fluid_cell/base",
 		"fluid": "gtmoremachine:item/creative_fluid_cell/overlay"


### PR DESCRIPTION
## What / 目的
此 PR 修复创造流体单元物品模型定义中的问题。

## Implementation Details / 实现细节
- 调整 `src/main/resources/assets/gtmoremachine/models/item/creative_fluid_cell.json` 的模型配置，使其与当前实现保持一致。

## Outcome / 结果
- 修复创造流体单元的物品模型显示问题。

## Potential Compatibility Issues / 潜在兼容性问题
- 无额外兼容性影响。