### PR TITLE
tooltip fix for huge buses

### DIFF
--- a/src/main/java/cn/qiuye/gtmoremachine/common/data/machines/CustomMachines.java
+++ b/src/main/java/cn/qiuye/gtmoremachine/common/data/machines/CustomMachines.java
@@ -16,7 +16,6 @@ import com.gregtechceu.gtceu.utils.FormattingUtil;
 import net.minecraft.network.chat.Component;
 
 import static cn.qiuye.gtmoremachine.common.data.machines.utils.CustomMachinesUtils.registerTieredMachines;
-import static cn.qiuye.gtmoremachine.common.machine.multiblock.part.HugeBusPartMachine.INV_MULTIPLE;
 import static cn.qiuye.gtmoremachine.common.registry.GTMMRegistration.GTMM;
 import static com.gregtechceu.gtceu.common.data.models.GTMachineModels.*;
 
@@ -39,7 +38,7 @@ public class CustomMachines {
                     .colorOverlayTieredHullModel("overlay_pipe_in_emissive", "overlay_pipe", OVERLAY_ITEM_HATCH_INPUT)
                     .tooltips(Component.translatable(HugeBusPartMachine.HUGE_ITEM_BUS_IMPORT_TOOLTIP),
                             Component.translatable("gtceu.universal.tooltip.item_storage_capacity",
-                                    (1 + tier) * HugeBusPartMachine.INV_MULTIPLE))
+                                    HugeBusPartMachine.getInventorySize(tier)))
                     .tooltips(Component.translatable("gtceu.part_sharing.enabled"))
                     .register(),
             ALL_TIERS);
@@ -55,7 +54,7 @@ public class CustomMachines {
                     .colorOverlayTieredHullModel("overlay_pipe_out_emissive", "overlay_pipe", OVERLAY_ITEM_HATCH_OUTPUT)
                     .tooltips(Component.translatable(HugeBusPartMachine.HUGE_ITEM_BUS_EXPORT_TOOLTIP),
                             Component.translatable("gtceu.universal.tooltip.item_storage_capacity",
-                                    (1 + tier) * INV_MULTIPLE))
+                                    HugeBusPartMachine.getInventorySize(tier)))
                     .tooltips(Component.translatable("gtceu.part_sharing.enabled"))
                     .register(),
             ALL_TIERS);
@@ -69,9 +68,10 @@ public class CustomMachines {
                         .abilities(GTMachineUtils.DUAL_INPUT_HATCH_ABILITIES)
                         .tooltips(Component.translatable("gtceu.machine.dual_hatch.import.tooltip"));
                 builder.tooltips(Component.translatable("gtceu.universal.tooltip.item_storage_capacity",
-                        (1 + tier) * INV_MULTIPLE))
+                        HugeBusPartMachine.getInventorySize(tier)))
                         .tooltips(Component.translatable("gtceu.universal.tooltip.fluid_storage_capacity_mult",
-                                tier, FormattingUtil.formatNumbers(Integer.MAX_VALUE)))
+                                HugeDualHatchPartMachine.getTankInventorySize(tier),
+                                FormattingUtil.formatNumbers(Integer.MAX_VALUE)))
                         .tooltips(Component.translatable("gtceu.part_sharing.enabled"));
                 return builder.register();
             },

--- a/src/main/java/cn/qiuye/gtmoremachine/common/data/machines/GTMMAEMachines.java
+++ b/src/main/java/cn/qiuye/gtmoremachine/common/data/machines/GTMMAEMachines.java
@@ -1,6 +1,8 @@
 package cn.qiuye.gtmoremachine.common.data.machines;
 
 import cn.qiuye.gtmoremachine.GTmm;
+import cn.qiuye.gtmoremachine.common.machine.multiblock.part.HugeBusPartMachine;
+import cn.qiuye.gtmoremachine.common.machine.multiblock.part.HugeDualHatchPartMachine;
 import cn.qiuye.gtmoremachine.integration.ae.machine.ProgrammableDualHatchPartMachine;
 import cn.qiuye.gtmoremachine.integration.ae.machine.ProgrammableHatchPartMachine;
 import cn.qiuye.gtmoremachine.integration.ae.machine.multiblock.part.MEOutputPartMachine;
@@ -17,7 +19,6 @@ import com.gregtechceu.gtceu.utils.FormattingUtil;
 import net.minecraft.network.chat.Component;
 
 import static cn.qiuye.gtmoremachine.common.data.machines.utils.CustomMachinesUtils.registerTieredMachines;
-import static cn.qiuye.gtmoremachine.common.machine.multiblock.part.HugeBusPartMachine.INV_MULTIPLE;
 import static cn.qiuye.gtmoremachine.common.registry.GTMMRegistration.GTMM;
 import static com.gregtechceu.gtceu.common.data.machines.GTMachineUtils.DUAL_HATCH_TIERS;
 
@@ -56,8 +57,9 @@ public class GTMMAEMachines {
                     .modelProperty(GTMachineModelProperties.IS_FORMED, false)
                     .workableTieredHullModel(GTCEu.id("block/machine/part/dual_hatch.import"))
                     .tooltips(Component.translatable("gtceu.machine.dual_hatch.import.tooltip"),
-                            Component.translatable("gtceu.universal.tooltip.item_storage_capacity", (1 + tier) * INV_MULTIPLE),
-                            Component.translatable("gtceu.universal.tooltip.fluid_storage_capacity_mult", tier, FormattingUtil.formatNumbers(Integer.MAX_VALUE)),
+                            Component.translatable("gtceu.universal.tooltip.item_storage_capacity", HugeBusPartMachine.getInventorySize(tier)),
+                            Component.translatable("gtceu.universal.tooltip.fluid_storage_capacity_mult", HugeDualHatchPartMachine.getTankInventorySize(tier),
+                                    FormattingUtil.formatNumbers(Integer.MAX_VALUE)),
                             Component.translatable("gtceu.part_sharing.enabled"))
                     .register(),
             DUAL_HATCH_TIERS);

--- a/src/main/java/cn/qiuye/gtmoremachine/common/data/machines/GTMMAEMachines.java
+++ b/src/main/java/cn/qiuye/gtmoremachine/common/data/machines/GTMMAEMachines.java
@@ -57,8 +57,10 @@ public class GTMMAEMachines {
                     .modelProperty(GTMachineModelProperties.IS_FORMED, false)
                     .workableTieredHullModel(GTCEu.id("block/machine/part/dual_hatch.import"))
                     .tooltips(Component.translatable("gtceu.machine.dual_hatch.import.tooltip"),
-                            Component.translatable("gtceu.universal.tooltip.item_storage_capacity", HugeBusPartMachine.getInventorySize(tier)),
-                            Component.translatable("gtceu.universal.tooltip.fluid_storage_capacity_mult", HugeDualHatchPartMachine.getTankInventorySize(tier),
+                            Component.translatable("gtceu.universal.tooltip.item_storage_capacity",
+                                    HugeBusPartMachine.getInventorySize(tier)),
+                            Component.translatable("gtceu.universal.tooltip.fluid_storage_capacity_mult",
+                                    HugeDualHatchPartMachine.getTankInventorySize(tier),
                                     FormattingUtil.formatNumbers(Integer.MAX_VALUE)),
                             Component.translatable("gtceu.part_sharing.enabled"))
                     .register(),

--- a/src/main/java/cn/qiuye/gtmoremachine/common/machine/multiblock/part/HugeBusPartMachine.java
+++ b/src/main/java/cn/qiuye/gtmoremachine/common/machine/multiblock/part/HugeBusPartMachine.java
@@ -108,8 +108,12 @@ public class HugeBusPartMachine extends TieredIOPartMachine implements IDistinct
     //////////////////////////////////////
 
     protected int getInventorySize() {
-        if (getTier() < GTValues.EV) return 1 + getTier();
-        else return (1 + getTier()) * INV_MULTIPLE;
+        return getInventorySize(this.getTier());
+    }
+
+    public static int getInventorySize(int tier) {
+        if (tier < GTValues.EV) return 1 + tier;
+        else return (1 + tier) * INV_MULTIPLE;
     }
 
     protected NotifiableItemStackHandler createInventory(IO io) {

--- a/src/main/java/cn/qiuye/gtmoremachine/common/machine/multiblock/part/HugeDualHatchPartMachine.java
+++ b/src/main/java/cn/qiuye/gtmoremachine/common/machine/multiblock/part/HugeDualHatchPartMachine.java
@@ -74,7 +74,11 @@ public class HugeDualHatchPartMachine extends HugeBusPartMachine {
     }
 
     protected int getTankInventorySize() {
-        return this.getTier() + 1;
+        return getTankInventorySize(this.getTier());
+    }
+
+    public static int getTankInventorySize(int tier) {
+        return tier + 1;
     }
 
     @Override


### PR DESCRIPTION
修复一个从gtmt就开始长期延续下来的巨型总线/总成/编程仓的tooltip错误。
顺带一提，上游gtm又更新了，datagen需要重跑。